### PR TITLE
[order] feat : 환경별 설정 파일 구성 및 테스트 환경 분리

### DIFF
--- a/services/order-service/build.gradle
+++ b/services/order-service/build.gradle
@@ -25,17 +25,30 @@ repositories {
 }
 
 dependencies {
+	// Spring Boot Starters
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// Kafka
 	implementation 'org.springframework.kafka:spring-kafka'
-	compileOnly 'org.projectlombok:lombok'
+
+	// Database
 	runtimeOnly 'org.postgresql:postgresql'
+
+	// Monitoring
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
+	// Lombok
+	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/services/order-service/src/main/resources/application-dev.yml
+++ b/services/order-service/src/main/resources/application-dev.yml
@@ -1,0 +1,42 @@
+spring:
+  # PostgreSQL 설정
+  datasource:
+    url: jdbc:postgresql://localhost:5432/order_db
+    username: order_user
+    password: order_pass
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 5
+      connection-timeout: 30000
+
+  # JPA 개발 설정
+  jpa:
+    hibernate:
+      ddl-auto: create-drop  # 개발 중에는 create-drop, 나중에 validate로 변경
+    show-sql: true
+
+  # Kafka 개발 설정
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: order-service-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: "*"
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+
+# 개발 환경 로깅
+logging:
+  level:
+    root: INFO
+    com.tradingsystem.order: DEBUG
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+    org.springframework.kafka: DEBUG
+  file:
+    path: logs  # 로그 파일 디렉토리 생성

--- a/services/order-service/src/main/resources/application-prod.yml
+++ b/services/order-service/src/main/resources/application-prod.yml
@@ -1,0 +1,26 @@
+spring:
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/order_db}
+    username: ${DB_USERNAME:order_user}
+    password: ${DB_PASSWORD:order_pass}
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 10
+
+  jpa:
+    hibernate:
+      ddl-auto: validate  # 운영에서는 validate만 사용
+    show-sql: false
+
+  kafka:
+    bootstrap-servers: ${KAFKA_BROKERS:localhost:9092}
+
+# 운영 환경 로깅
+logging:
+  level:
+    root: WARN
+    com.tradingsystem.order: INFO
+    org.hibernate: WARN
+    org.springframework.kafka: WARN
+  file:
+    path: /var/log/order-service  # 운영 로그 경로

--- a/services/order-service/src/main/resources/application.properties
+++ b/services/order-service/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=order-service

--- a/services/order-service/src/main/resources/application.yml
+++ b/services/order-service/src/main/resources/application.yml
@@ -1,0 +1,47 @@
+spring:
+  application:
+    name: order-service # Logback?? ??
+
+  profiles:
+    active: dev
+
+  # JPA ?? ??
+  jpa:
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true
+
+# ?? ??
+server:
+  port: 8100
+  shutdown: graceful
+
+# Actuator ??
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus,metrics,loggers
+      base-path: /actuator
+  endpoint:
+    health:
+      show-details: always
+    loggers:
+      enabled: true  # ??? ?? ?? ?? ??
+  metrics:
+    export:
+      prometheus:
+        enabled: true
+  health:
+    livenessState:
+      enabled: true
+    readinessState:
+      enabled: true
+
+# ?? ?? (logback-spring.xml ??)
+logging:
+  level:
+    root: INFO
+    com.tradingsystem.order: DEBUG

--- a/services/order-service/src/test/resources/application-test.yml
+++ b/services/order-service/src/test/resources/application-test.yml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+
+  kafka:
+    bootstrap-servers: ${spring.embedded.kafka.brokers}
+
+# 테스트 환경 로깅
+logging:
+  level:
+    root: WARN
+    com.tradingsystem.order: DEBUG


### PR DESCRIPTION
## What
- **공통 설정** (application.yml)
  - JPA 설정 (open-in-view: false, format_sql: true)
  - 서버 포트 8100, graceful shutdown 활성화
  - Actuator 엔드포인트 노출 (health, prometheus, metrics)
  - 기본 로깅 레벨 설정 (root: INFO, order: DEBUG)

- **개발 환경** (application-dev.yml)
  - PostgreSQL 연결 (localhost:5432/order_db)
  - Hikari CP 설정 (max: 10, min: 5)
  - DDL auto: create-drop
  - SQL 로깅 활성화
  - Kafka 연결 (localhost:9092)

- **운영 환경** (application-prod.yml)
  - 환경변수 기반 설정 (DB_URL, DB_USERNAME, DB_PASSWORD)
  - DDL auto: validate
  - SQL 로깅 비활성화
  - 로깅 레벨 최소화 (root: WARN)

- **테스트 환경** (application-test.yml)
  - H2 in-memory DB 설정
  - Embedded Kafka 설정
  - DDL auto: create-drop
  - 테스트용 로깅 레벨 간소화

- **의존성 추가** (build.gradle)
  - H2 데이터베이스 테스트 의존성 추가

## Why
- 환경별 설정 분리로 개발/운영/테스트 환경 독립성 확보
- 테스트 환경에서 H2 in-memory DB 사용으로 빠른 테스트 실행
- 운영 환경 보안 강화 (환경변수 기반 설정, 로깅 최소화)
- Actuator를 통한 모니터링 메트릭 노출 준비

## Impact
- **Breaking 없음**
- **Contract 변경 없음**
- 테스트 실행 속도 개선 (PostgreSQL → H2)
- 운영 환경 로그 볼륨 감소

## Checklist
- [ ] H2 테스트 DB 정상 동작 확인

Related: #5