### PR TITLE
[order] feat: Docker Compose 로컬 개발 환경 구성 및 보안 강화

### DIFF
--- a/services/order-service/.env.example
+++ b/services/order-service/.env.example
@@ -1,0 +1,13 @@
+# PostgreSQL Configuration
+POSTGRES_DB=order_db
+POSTGRES_USER=order_user
+POSTGRES_PASSWORD=your_secure_password_here
+
+# Kafka Configuration
+KAFKA_CLUSTER_ID=your_cluster_id_here
+KAFKA_EXTERNAL_PORT=9092
+KAFKA_INTERNAL_PORT=29092
+KAFKA_CONTROLLER_PORT=9093
+
+# Grafana Configuration
+GRAFANA_ADMIN_PASSWORD=your_admin_password_here

--- a/services/order-service/.env.example
+++ b/services/order-service/.env.example
@@ -1,13 +1,17 @@
-# PostgreSQL Configuration
+# PostgreSQL Configuration (Required)
 POSTGRES_DB=order_db
 POSTGRES_USER=order_user
-POSTGRES_PASSWORD=your_secure_password_here
+POSTGRES_PASSWORD=
 
-# Kafka Configuration
-KAFKA_CLUSTER_ID=your_cluster_id_here
+# Kafka Configuration (Required)
+KAFKA_CLUSTER_ID=
 KAFKA_EXTERNAL_PORT=9092
-KAFKA_INTERNAL_PORT=29092
-KAFKA_CONTROLLER_PORT=9093
 
-# Grafana Configuration
-GRAFANA_ADMIN_PASSWORD=your_admin_password_here
+# Grafana Configuration (Required)
+GRAFANA_ADMIN_PASSWORD=
+
+# 보안 가이드:
+# - POSTGRES_PASSWORD: 최소 16자 이상, 대소문자/숫자/특수문자 조합
+# - KAFKA_CLUSTER_ID: 22자 Base64 문자열 (생성 방법: echo $(cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 22 | head -n 1))
+# - GRAFANA_ADMIN_PASSWORD: 최소 12자 이상, 대소문자/숫자/특수문자 조합
+

--- a/services/order-service/.gitignore
+++ b/services/order-service/.gitignore
@@ -35,3 +35,9 @@ out/
 
 ### VS Code ###
 .vscode/
+
+
+# Environment variables
+.env
+.env.local
+.env.*.local

--- a/services/order-service/.gitignore
+++ b/services/order-service/.gitignore
@@ -41,3 +41,4 @@ out/
 .env
 .env.local
 .env.*.local
+

--- a/services/order-service/docker-compose.yml
+++ b/services/order-service/docker-compose.yml
@@ -3,12 +3,12 @@ version: '3.8'
 services:
   # PostgreSQL
   postgres:
-    image: postgres:15-alpine
+    image: postgres:16-alpine
     container_name: order-postgres
     environment:
-      POSTGRES_DB: order_db
-      POSTGRES_USER: order_user
-      POSTGRES_PASSWORD: order_pass
+      POSTGRES_DB: ${POSTGRES_DB:-order_db}
+      POSTGRES_USER: ${POSTGRES_USER:-order_user}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-order_pass}
     ports:
       - "5432:5432"
     volumes:
@@ -18,32 +18,35 @@ services:
 
   # Kafka (KRaft 모드)
   kafka:
-    image: confluentinc/cp-kafka:7.5.0
+    image: confluentinc/cp-kafka:7.8.0
     container_name: order-kafka
     ports:
-      - "9092:9092"
-      - "9093:9093"
+      - "${KAFKA_EXTERNAL_PORT:-9092}:9092"
     environment:
       KAFKA_NODE_ID: 1
       KAFKA_PROCESS_ROLES: broker,controller
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      # 내부(29092), 외부(9092), 컨트롤러(9093) 리스너 분리
+      KAFKA_LISTENERS: PLAINTEXT_INTERNAL://0.0.0.0:29092,PLAINTEXT_EXTERNAL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
+      # 내부는 kafka:29092, 외부는 localhost:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT_INTERNAL://kafka:29092,PLAINTEXT_EXTERNAL://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT_INTERNAL:PLAINTEXT,PLAINTEXT_EXTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT
       KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      # 브로커 간 통신은 내부 리스너 사용
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT_INTERNAL
       KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_LOG_DIRS: /var/lib/kafka/data
-      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+      CLUSTER_ID: ${KAFKA_CLUSTER_ID:-MkU3OEVBNTcwNTJENDM2Qk}
     volumes:
       - kafka-data:/var/lib/kafka/data
     networks:
       - order-network
 
-  # Prometheus (기본 설정)
+  # Prometheus
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v3.0.1
     container_name: order-prometheus
     ports:
       - "9090:9090"
@@ -52,14 +55,14 @@ services:
     networks:
       - order-network
 
-  # Grafana (기본 설정)
+  # Grafana
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:11.4.0
     container_name: order-grafana
     ports:
       - "3000:3000"
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
     volumes:
       - grafana-data:/var/lib/grafana
     networks:

--- a/services/order-service/docker-compose.yml
+++ b/services/order-service/docker-compose.yml
@@ -1,0 +1,76 @@
+version: '3.8'
+
+services:
+  # PostgreSQL
+  postgres:
+    image: postgres:15-alpine
+    container_name: order-postgres
+    environment:
+      POSTGRES_DB: order_db
+      POSTGRES_USER: order_user
+      POSTGRES_PASSWORD: order_pass
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    networks:
+      - order-network
+
+  # Kafka (KRaft 모드)
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    container_name: order-kafka
+    ports:
+      - "9092:9092"
+      - "9093:9093"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+    volumes:
+      - kafka-data:/var/lib/kafka/data
+    networks:
+      - order-network
+
+  # Prometheus (기본 설정)
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: order-prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - prometheus-data:/prometheus
+    networks:
+      - order-network
+
+  # Grafana (기본 설정)
+  grafana:
+    image: grafana/grafana:latest
+    container_name: order-grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - grafana-data:/var/lib/grafana
+    networks:
+      - order-network
+
+volumes:
+  postgres-data:
+  kafka-data:
+  prometheus-data:
+  grafana-data:
+
+networks:
+  order-network:
+    driver: bridge

--- a/services/order-service/docker-compose.yml
+++ b/services/order-service/docker-compose.yml
@@ -6,9 +6,9 @@ services:
     image: postgres:16-alpine
     container_name: order-postgres
     environment:
-      POSTGRES_DB: ${POSTGRES_DB:-order_db}
-      POSTGRES_USER: ${POSTGRES_USER:-order_user}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-order_pass}
+      POSTGRES_DB: ${POSTGRES_DB:?POSTGRES_DB is not set in .env file}
+      POSTGRES_USER: ${POSTGRES_USER:?POSTGRES_USER is not set in .env file}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is not set in .env file}
     ports:
       - "5432:5432"
     volumes:
@@ -21,7 +21,7 @@ services:
     image: confluentinc/cp-kafka:7.8.0
     container_name: order-kafka
     ports:
-      - "${KAFKA_EXTERNAL_PORT:-9092}:9092"
+      - "${KAFKA_EXTERNAL_PORT}:9092"
     environment:
       KAFKA_NODE_ID: 1
       KAFKA_PROCESS_ROLES: broker,controller
@@ -38,7 +38,7 @@ services:
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_LOG_DIRS: /var/lib/kafka/data
-      CLUSTER_ID: ${KAFKA_CLUSTER_ID:-MkU3OEVBNTcwNTJENDM2Qk}
+      CLUSTER_ID: ${KAFKA_CLUSTER_ID:?KAFKA_CLUSTER_ID is not set in .env file}
     volumes:
       - kafka-data:/var/lib/kafka/data
     networks:
@@ -62,7 +62,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD is not set in .env file}
     volumes:
       - grafana-data:/var/lib/grafana
     networks:
@@ -77,3 +77,4 @@ volumes:
 networks:
   order-network:
     driver: bridge
+


### PR DESCRIPTION
## What
- PostgreSQL 16-alpine, Kafka 7.8.0, Prometheus v3.0.1, Grafana 11.4.0 컨테이너 구성
- Kafka 내부/외부 리스너 분리 (내부: 29092, 외부: 9092)
- 환경변수 외부화 (.env 파일)
- order-network 브릿지 네트워크 구성
- 볼륨을 통한 데이터 영속성 보장

## Why
- Order 서비스 로컬 개발 인프라 구축
- 민감 정보 Git 노출 방지 및 보안 강화
- 이미지 버전 고정으로 환경 일관성 보장

## How
- Docker Compose 멀티 컨테이너 구성
- KRaft 모드 Kafka
- .env.example 템플릿 추가
- Kafka 컨트롤러 포트 외부 노출 제거

## Impact
- Breaking: 없음
- .env 파일 생성 필요 (.env.example 참고)
- MSA 서비스는 kafka:29092, 호스트는 localhost:9092 사용

## Test
- `docker-compose up -d` 실행 후 각 서비스 동작 확인
- PostgreSQL, Kafka, Prometheus, Grafana 접속 확인
- 버전 확인: `docker-compose images`

## Checklist
- [x] Docker Compose 파일 작성 완료
- [x] 환경변수 외부화 및 .gitignore 추가
- [x] 버전 고정 및 보안 강화 완료

Closes #5