### PR TITLE
[order] feat: 주문 도메인 Enum 클래스 구현

### DIFF
--- a/services/order-service/src/main/java/com/tradingsystem/order/domain/OrderSide.java
+++ b/services/order-service/src/main/java/com/tradingsystem/order/domain/OrderSide.java
@@ -3,12 +3,16 @@ package com.tradingsystem.order.domain;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * 주문의 매수/매도 방향을 나타내는 Enum 클래스입니다.
+ */
+
 @Getter
 @RequiredArgsConstructor
 public enum OrderSide {
     BUY("매수", 1),
     SELL("매도", -1);
 
-    private final String displayName;
-    private final int multiplier;  // 수량 계산용
+    private final String displayName; // UI에 표시될 이름 (예: "매수", "매도")
+    private final int multiplier;  // 주문 수량 계산에 사용되는 승수(매수(BUY)는 1, 매도(SELL)는 -1 값)
 }

--- a/services/order-service/src/main/java/com/tradingsystem/order/domain/OrderSide.java
+++ b/services/order-service/src/main/java/com/tradingsystem/order/domain/OrderSide.java
@@ -1,0 +1,14 @@
+package com.tradingsystem.order.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderSide {
+    BUY("매수", 1),
+    SELL("매도", -1);
+
+    private final String displayName;
+    private final int multiplier;  // 수량 계산용
+}

--- a/services/order-service/src/main/java/com/tradingsystem/order/domain/OrderStatus.java
+++ b/services/order-service/src/main/java/com/tradingsystem/order/domain/OrderStatus.java
@@ -1,0 +1,20 @@
+package com.tradingsystem.order.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderStatus {
+    PENDING("대기중", "주문이 생성되었습니다"),
+    RESERVED("예약됨", "장 시간 외 예약 주문"),
+    ACCEPTED("승인됨", "예약이 승인되어 체결 대기 중입니다"),
+    REJECTED("거부됨", "잔고 부족 등으로 주문이 거부되었습니다"),
+    FILLED("체결완료", "주문이 완전히 체결되었습니다"),
+    PARTIALLY_FILLED("부분체결", "주문이 일부만 체결되었습니다"),
+    CANCELLED("취소됨", "사용자가 주문을 취소했습니다"),
+    EXPIRED("만료됨", "24시간 경과로 주문이 만료되었습니다");
+
+    private final String displayName;
+    private final String description;
+}

--- a/services/order-service/src/main/java/com/tradingsystem/order/domain/OrderStatus.java
+++ b/services/order-service/src/main/java/com/tradingsystem/order/domain/OrderStatus.java
@@ -3,6 +3,12 @@ package com.tradingsystem.order.domain;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * 주문의 생명주기에 따른 상태를 관리하는 Enum 클래스입니다.
+ * PENDING -> (RESERVED) -> ACCEPTED -> PARTIALLY_FILLED -> FILLED
+ * 각 단계에서 REJECTED, CANCELLED, EXPIRED 상태로 변경될 수 있습니다.
+ */
+
 @Getter
 @RequiredArgsConstructor
 public enum OrderStatus {
@@ -10,11 +16,11 @@ public enum OrderStatus {
     RESERVED("예약됨", "장 시간 외 예약 주문"),
     ACCEPTED("승인됨", "예약이 승인되어 체결 대기 중입니다"),
     REJECTED("거부됨", "잔고 부족 등으로 주문이 거부되었습니다"),
-    FILLED("체결완료", "주문이 완전히 체결되었습니다"),
     PARTIALLY_FILLED("부분체결", "주문이 일부만 체결되었습니다"),
+    FILLED("체결완료", "주문이 완전히 체결되었습니다"),
     CANCELLED("취소됨", "사용자가 주문을 취소했습니다"),
     EXPIRED("만료됨", "24시간 경과로 주문이 만료되었습니다");
 
-    private final String displayName;
-    private final String description;
+    private final String displayName; // UI에 표시될 이름
+    private final String description; // 상태에 대한 상세 설명
 }

--- a/services/order-service/src/main/java/com/tradingsystem/order/domain/OrderType.java
+++ b/services/order-service/src/main/java/com/tradingsystem/order/domain/OrderType.java
@@ -1,0 +1,14 @@
+package com.tradingsystem.order.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderType {
+    MARKET("시장가", "현재 시장가로 즉시 체결"),
+    LIMIT("지정가", "지정한 가격에 도달하면 체결");
+
+    private final String displayName;
+    private final String description;
+}

--- a/services/order-service/src/main/java/com/tradingsystem/order/domain/OrderType.java
+++ b/services/order-service/src/main/java/com/tradingsystem/order/domain/OrderType.java
@@ -3,12 +3,17 @@ package com.tradingsystem.order.domain;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * 주문 유형(시장가, 지정가)을 정의하는 Enum 클래스입니다.
+ */
+
 @Getter
 @RequiredArgsConstructor
 public enum OrderType {
     MARKET("시장가", "현재 시장가로 즉시 체결"),
     LIMIT("지정가", "지정한 가격에 도달하면 체결");
 
-    private final String displayName;
-    private final String description;
+    private final String displayName; // UI에 표시될 이름 (예: "시장가", "지정가")
+    private final String description; // 주문 유형에 대한 상세 설명
 }
+


### PR DESCRIPTION
## What
- **OrderStatus**: 주문 생명주기 상태 관리 (8개 상태)
  - PENDING, RESERVED, ACCEPTED, PARTIAL_FILLED, FILLED, REJECTED, CANCELLED, EXPIRED
- **OrderType**: 주문 유형 (MARKET, LIMIT)
- **OrderSide**: 매수/매도 구분 (BUY, SELL)
- 각 Enum에 description 필드 추가로 가독성 향상

## Why
- 주문 도메인 핵심 상태 및 타입 정의
- 타입 안정성 보장 및 잘못된 값 입력 방지
- 코드 가독성 및 유지보수성 향상

## How
- Lombok @Getter, @RequiredArgsConstructor 사용
- description 필드로 각 상태/타입 설명 제공
- 장시간 기반 처리를 위한 RESERVED 상태 포함

## Impact
- Breaking: 없음
- 주문 엔티티 및 서비스 로직에서 사용 예정

## Checklist
- [x] Enum 클래스 구현 완료
- [x] 주문 생명주기 상태 정의 완료

Related: #6