### PR TITLE
[order] feat: 핵심 도메인 엔티티(Order, Trade, Outbox) 구현 및 로직 캡슐화

### DIFF
--- a/services/order-service/src/main/java/com/tradingsystem/order/domain/Order.java
+++ b/services/order-service/src/main/java/com/tradingsystem/order/domain/Order.java
@@ -1,0 +1,181 @@
+package com.tradingsystem.order.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * 주문 엔티티
+ * - 주문의 메타데이터 및 상태 관리
+ * - 시장가/지정가 구분
+ * - 만료 시간 관리 (LIMIT만 설정)
+ */
+
+@Entity
+@Table(name = "orders",
+        indexes = {
+            @Index(name = "idx_user_id_created_at", columnList = "userId, createdAt DESC")
+        },
+        uniqueConstraints = {
+            @UniqueConstraint(name = "uk_user_client_order", columnNames = {"userId", "clientOrderId"})
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(toBuilder = true)
+@EntityListeners(AuditingEntityListener.class)
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    /**
+     * 클라이언트 주문 ID (멱등성 보장용)
+     */
+    @Column(name = "client_order_id", nullable = false, length = 100)
+    private String clientOrderId;
+
+    @Column(nullable = false, length = 20)
+    private String symbol;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private OrderSide side;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private OrderType type;
+
+    @Column(precision = 19, scale = 4)
+    private BigDecimal price; // 지정가 주문(LIMIT)일 경우 필수 입력
+
+    @Column(nullable = false)
+    private Integer quantity;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Integer filledQuantity = 0;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    @Builder.Default
+    private OrderStatus status = OrderStatus.PENDING;
+
+    private LocalDateTime expiresAt; // 지정가 주문 만료 시간
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    // === 비즈니스 메서드 ===
+
+    /**
+     * 주문 상태 업데이트
+     */
+    public void updateStatus(OrderStatus newStatus) {
+        this.status = newStatus;
+    }
+
+    /**
+     * 체결 수량 추가 및 상태 업데이트
+     * @param quantity 실제로 체결된 수량
+     */
+    public void addFilledQuantity(Integer quantity) {
+        if (this.filledQuantity + quantity > this.quantity) {
+            throw new IllegalArgumentException("체결 수량(" + quantity + ")이 남은 수량(" + getRemainingQuantity() + ")을 초과합니다.");
+        }
+
+        this.filledQuantity += quantity;
+
+        if (this.filledQuantity.equals(this.quantity)) {
+            this.status = OrderStatus.FILLED;
+        } else if (this.filledQuantity > 0) {
+            this.status = OrderStatus.PARTIALLY_FILLED;
+        }
+    }
+
+    /**
+     * 시장가 주문 여부
+     */
+    public boolean isMarketOrder() {
+        return this.type == OrderType.MARKET;
+    }
+
+    /**
+     * 지정가 주문 여부
+     */
+    public boolean isLimitOrder() {
+        return this.type == OrderType.LIMIT;
+    }
+
+    /**
+     * 매수 주문 여부
+     */
+    public boolean isBuyOrder() {
+        return this.side == OrderSide.BUY;
+    }
+
+    /**
+     * 매도 주문 여부
+     */
+    public boolean isSellOrder() {
+        return this.side == OrderSide.SELL;
+    }
+
+    /**
+     * 남은 수량 계산
+     */
+    public Integer getRemainingQuantity() {
+        return this.quantity - this.filledQuantity;
+    }
+
+    /**
+     * 주문 만료 여부 확인
+     */
+    public boolean isExpired() {
+        // 시장가 주문은 만료 시간이 없습니다.
+        if (this.type == OrderType.MARKET) {
+            return false;
+        }
+
+        // 만료 시간이 설정되어 있고, 현재 시간이 만료 시간을 지났다면 true
+        return expiresAt != null && LocalDateTime.now().isAfter(expiresAt);
+    }
+
+    /**
+     * 주문이 현재 체결 가능 상태(Active)인지 확인
+     * (PENDING 또는 PARTIALLY_FILLED 상태이며, 만료되지 않음)
+     */
+    public boolean isTradable() {
+        // 1. 상태가 체결 가능한 상태인지 확인
+        boolean isActiveStatus = this.status == OrderStatus.PENDING || this.status == OrderStatus.PARTIALLY_FILLED;
+
+        if (!isActiveStatus) {
+            return false; // 이미 FILLED, CANCELED, EXPIRED 상태 등
+        }
+
+        // 2. 지정가 주문인 경우 만료 여부 확인
+        if (this.isLimitOrder() && this.isExpired()) {
+            return false;
+        }
+
+        return true;
+    }
+
+
+}
+

--- a/services/order-service/src/main/java/com/tradingsystem/order/domain/OrderTrade.java
+++ b/services/order-service/src/main/java/com/tradingsystem/order/domain/OrderTrade.java
@@ -1,0 +1,60 @@
+package com.tradingsystem.order.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "order_trades",
+        indexes = {
+            @Index(name = "idx_order_id", columnList = "order_id"),
+            @Index(name = "idx_trade_id", columnList = "tradeId", unique = true)
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class OrderTrade {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long orderId;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String tradeId; // Execution에서 받은 체결 ID (멱등성 보장)
+
+    @Column(nullable = false, length = 20)
+    private String symbol;
+
+    @Column(unique = false, precision = 19, scale = 4)
+    private BigDecimal executedPrice;
+
+    @Column(nullable = false)
+    private Integer executedQuantity;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private OrderSide side;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime executedAt;
+
+    // === 비즈니스 메서드 ===
+
+    /**
+     * 체결 금액 계산
+     */
+    public BigDecimal getTotalAmount() {
+        return executedPrice.multiply(BigDecimal.valueOf(executedQuantity));
+    }
+
+}

--- a/services/order-service/src/main/java/com/tradingsystem/order/domain/OutboxEvent.java
+++ b/services/order-service/src/main/java/com/tradingsystem/order/domain/OutboxEvent.java
@@ -1,0 +1,63 @@
+package com.tradingsystem.order.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "outbox_events",
+        indexes = {
+            @Index(name = "idx_published_created_at", columnList = "published, createdAt")
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class OutboxEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String eventId; // UUID(멱등성 보장)
+
+    @Column(nullable = false, length = 50)
+    private String eventType;  // OrderPlaced, OrderCancelled, OrderExpired
+
+    @Column(nullable = false)
+    private Long aggregateId; // Order ID
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String payload; // JSON 형태의 이벤트 데이터
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Boolean published = false;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime publishedAt;
+
+    // === 비즈니스 메서드 ===
+    /**
+     * 이벤트 발행 완료 처리
+     */
+    public void markAsPublished() {
+        this.published =true;
+        this.publishedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 발행 대기 중인 이벤트 여부
+     */
+    public boolean isPending() {
+        return !this.published;
+    }
+}


### PR DESCRIPTION
## What: 핵심 도메인 엔티티 및 로직 구현
* **Order 엔티티 추가:** 주문의 메타데이터, 상태, 수량(`filledQuantity`) 및 만료 시간(`expiresAt`) 관리.
* **OrderTrade 엔티티 추가:** 체결 엔진(Execution)의 불변 체결 기록을 저장하여 체결 내역 API의 데이터 소스로 활용.
* **OutboxEvent 엔티티 추가:** Transactional Outbox 패턴을 구현하여 DB 트랜잭션과 이벤트 발행 간의 원자성(Atomicity) 보장.

## Why: MSA 환경에서 데이터 일관성 및 기능 분리
* **데이터 소유권:** Order 서비스가 주문 및 체결 기록의 **단일 진실 공급원(SSOT)**으로서 모든 상태 변경의 최종 책임을 수행.
* **멱등성 확보:** `OrderTrade.tradeId`와 `OutboxEvent.eventId`의 **UNIQUE 제약조건**을 통해 외부 시스템의 중복 요청 및 이벤트 재처리로부터 데이터 무결성 방어.
* **DDD 원칙 준수:** 모든 도메인 객체에 `isTradable()`, `isExpired()`, `addFilledQuantity()`, `markAsPublished()` 등 핵심 비즈니스 로직을 캡슐화하여 높은 응집도 확보.

## How: 구현 방식
* **JPA/Lombok:** `@Builder`, `@NoArgsConstructor(PROTECTED)`, `@AllArgsConstructor(PRIVATE)`를 사용하여 안전한 객체 생성 및 ORM 환경 최적화.
* **인덱스 최적화:** `idx_user_id_created_at`, `idx_published_created_at` 등을 통해 조회 성능 최적화.
* **도메인 로직:** `Order.addFilledQuantity()`에 수량 초과 방어 로직 포함.

## Impact: BREAKING/계약 변경 여부
* Breaking 없음.
* Contract 변경 없음 (Order 서비스 내부 데이터 구조 변경).
* **새로운 DB 스키마 추가:** `orders`, `order_trades`, `outbox_events` 테이블이 추가됨.

## Checklist
* [ ] 연동 서비스 영향 검토 (Execution 서비스와 체결 결과를 주고받는 API 정의 필요)