### PR TITLE
[order] feat: JPA Auditing 활성화

### DIFF
--- a/services/order-service/src/main/java/com/tradingsystem/order/config/JpaConfig.java
+++ b/services/order-service/src/main/java/com/tradingsystem/order/config/JpaConfig.java
@@ -1,0 +1,12 @@
+package com.tradingsystem.order.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+    // JPA Auditing 활성화
+    // @CreatedDate, @LastModifiedDate 자동 처리
+}
+

--- a/services/order-service/src/main/java/com/tradingsystem/order/domain/BaseTimeEntity.java
+++ b/services/order-service/src/main/java/com/tradingsystem/order/domain/BaseTimeEntity.java
@@ -1,0 +1,26 @@
+package com.tradingsystem.order.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+}

--- a/services/order-service/src/main/java/com/tradingsystem/order/domain/Order.java
+++ b/services/order-service/src/main/java/com/tradingsystem/order/domain/Order.java
@@ -29,8 +29,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(toBuilder = true)
-@EntityListeners(AuditingEntityListener.class)
-public class Order {
+public class Order extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -72,14 +71,6 @@ public class Order {
     private OrderStatus status = OrderStatus.PENDING;
 
     private LocalDateTime expiresAt; // 지정가 주문 만료 시간
-
-    @CreatedDate
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(nullable = false)
-    private LocalDateTime updatedAt;
 
     // === 비즈니스 메서드 ===
 

--- a/services/order-service/src/main/java/com/tradingsystem/order/domain/OrderTrade.java
+++ b/services/order-service/src/main/java/com/tradingsystem/order/domain/OrderTrade.java
@@ -18,8 +18,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-@EntityListeners(AuditingEntityListener.class)
-public class OrderTrade {
+public class OrderTrade extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -43,10 +42,6 @@ public class OrderTrade {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 10)
     private OrderSide side;
-
-    @CreatedDate
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime executedAt;
 
     // === 비즈니스 메서드 ===
 

--- a/services/order-service/src/main/java/com/tradingsystem/order/domain/OutboxEvent.java
+++ b/services/order-service/src/main/java/com/tradingsystem/order/domain/OutboxEvent.java
@@ -19,8 +19,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-@EntityListeners(AuditingEntityListener.class)
-public class OutboxEvent {
+public class OutboxEvent extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -42,10 +41,6 @@ public class OutboxEvent {
     @Builder.Default
     private boolean published = false;
 
-    @CreatedDate
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
     private LocalDateTime publishedAt;
 
     // === 비즈니스 메서드 ===
@@ -54,6 +49,10 @@ public class OutboxEvent {
      *  @param publishedTime 이벤트가 실제로 발행 완료된 시간
      */
     public void markAsPublished(LocalDateTime publishedTime) {
+        if (this.published) {
+            // 이미 발행된 이벤트에 대한 중복 호출 방지
+            throw new IllegalStateException("이미 발행된 이벤트입니다. EventId: " + this.eventId);
+        }
         this.published =true;
         this.publishedAt = publishedTime;
     }

--- a/services/order-service/src/main/java/com/tradingsystem/order/repository/OrderRepository.java
+++ b/services/order-service/src/main/java/com/tradingsystem/order/repository/OrderRepository.java
@@ -1,0 +1,61 @@
+package com.tradingsystem.order.repository;
+
+import com.tradingsystem.order.domain.Order;
+import com.tradingsystem.order.domain.OrderStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    /**
+     * 사용자별 주문 조회 (최신순)
+     */
+    List<Order> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    /**
+     * 사용자 + 상태별 주문 조회
+     */
+    List<Order> findByUserIdAndStatus(Long userId, OrderStatus status);
+
+    /**
+     * clientOrderId 기반 중복 체크 (멱등성 보장)
+     */
+    Optional<Order> findByUserIdAndClientOrderId(Long userId, String clientOrderId);
+
+    /**
+     * 만료 대상 지정가 주문 조회
+     * - 상태 : PENDING 또는 ACCEPTED
+     * - 만료 시간 < 현재 시간
+     */
+    @Query("SELECT o FROM Order o WHERE o.status IN :statuses " +
+            "AND o.expiresAt IS NOT NULL AND o.expiresAt < :now")
+    List<Order> findExpiredOrders(
+            @Param("statuses") List<OrderStatus> statuses,
+            @Param("now") LocalDateTime now
+    );
+
+    /**
+     * 예약 주문 조회 (장시간 외 생성된 주문)
+     * - 상태 : RESERVED
+     */
+    List<Order> findByStatus(OrderStatus status);
+
+    /**
+     * 종목 별 활성 주문 조회 (체결 가능한 주문)
+     */
+    @Query("SELECT o FROM Order o WHERE o.symbol = :symbol " +
+            "AND o.status IN :statuses")
+    List<Order> findActiveOrdersBySymbol(
+            @Param("symbol") String symbol,
+            @Param("statuses") List<OrderStatus> statuses
+    );
+
+
+}

--- a/services/order-service/src/main/java/com/tradingsystem/order/repository/OrderTradeRepository.java
+++ b/services/order-service/src/main/java/com/tradingsystem/order/repository/OrderTradeRepository.java
@@ -16,7 +16,7 @@ public interface OrderTradeRepository extends JpaRepository<OrderTrade, Long> {
     /**
      * 주문 별 체결 이력 조회 (시간순)
      */
-    List<OrderTrade> findByOrderIdOrderByExecutedAtAsc(Long orderId);
+    List<OrderTrade> findByOrderIdOrderByCreatedAtAsc(Long orderId);
 
     /**
      * tradeId 기반 중복 체크 (멱등성 보장)
@@ -26,7 +26,7 @@ public interface OrderTradeRepository extends JpaRepository<OrderTrade, Long> {
     /**
      * 주문 별 총 체결 수량 계산
      */
-    @Query("SELECT COALESCE(SUM(ot.quantity), 0) FROM OrderTrade ot " +
+    @Query("SELECT COALESCE(SUM(ot.executedQuantity), 0) FROM OrderTrade ot " +
            "WHERE ot.orderId = :orderId" )
     BigDecimal calculateTotalFilledQuantity(@Param("orderId") Long orderId);
 
@@ -34,7 +34,7 @@ public interface OrderTradeRepository extends JpaRepository<OrderTrade, Long> {
      * 주문별 평균 체결가 계산
      * (체결가 * 수량)의 합 / 총 수량
      */
-    @Query("SELECT COALESCE(SUM(ot.price * ot.quantity) / SUM(ot.quantity), 0) " +
+    @Query("SELECT COALESCE(SUM(ot.executedPrice * ot.executedQuantity) / SUM(ot.executedQuantity), 0) " +
             "FROM OrderTrade ot WHERE ot.orderId = :orderId")
     BigDecimal calculateAveragePrice(@Param("orderId") Long orderId);
 

--- a/services/order-service/src/main/java/com/tradingsystem/order/repository/OrderTradeRepository.java
+++ b/services/order-service/src/main/java/com/tradingsystem/order/repository/OrderTradeRepository.java
@@ -1,0 +1,43 @@
+package com.tradingsystem.order.repository;
+
+import com.tradingsystem.order.domain.OrderTrade;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface OrderTradeRepository extends JpaRepository<OrderTrade, Long> {
+
+    /**
+     * 주문 별 체결 이력 조회 (시간순)
+     */
+    List<OrderTrade> findByOrderIdOrderByExecutedAtAsc(Long orderId);
+
+    /**
+     * tradeId 기반 중복 체크 (멱등성 보장)
+     */
+    Optional<OrderTrade> findByTradeId(String tradeId);
+
+    /**
+     * 주문 별 총 체결 수량 계산
+     */
+    @Query("SELECT COALESCE(SUM(ot.quantity), 0) FROM OrderTrade ot " +
+           "WHERE ot.orderId = :orderId" )
+    BigDecimal calculateTotalFilledQuantity(@Param("orderId") Long orderId);
+
+    /**
+     * 주문별 평균 체결가 계산
+     * (체결가 * 수량)의 합 / 총 수량
+     */
+    @Query("SELECT COALESCE(SUM(ot.price * ot.quantity) / SUM(ot.quantity), 0) " +
+            "FROM OrderTrade ot WHERE ot.orderId = :orderId")
+    BigDecimal calculateAveragePrice(@Param("orderId") Long orderId);
+
+
+
+}

--- a/services/order-service/src/main/java/com/tradingsystem/order/repository/OutboxEventRepository.java
+++ b/services/order-service/src/main/java/com/tradingsystem/order/repository/OutboxEventRepository.java
@@ -1,0 +1,36 @@
+package com.tradingsystem.order.repository;
+
+import com.tradingsystem.order.domain.OutboxEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface OutboxEventRepository extends JpaRepository<OutboxEvent, Long> {
+    /**
+     * eventId 기반 중복 체크(멱등성 보장)
+     */
+    Optional<OutboxEvent> findByEventId(String eventId);
+
+    /**
+     * 미발행 이벤트 조회 (CDC 백업용)
+     * - published = false
+     * - 생성시간 기준 오래된 순
+     */
+    List<OutboxEvent> findByPublishedFalseOrderByCreatedAtAsc();
+
+    /**
+     * 오래된 발행 완료 이벤트 조회 (정리용)
+     * - published = true
+     * - 생성시간 < 기준시간
+     */
+    @Query("SELECT oe FROM OutboxEvent oe WHERE oe.published = true " +
+            "AND oe.createdAt < :cutoffTime")
+    List<OutboxEvent> findOldPublishedEvents(@Param("cutoffTime") LocalDateTime cutoffTime);
+
+}

--- a/services/order-service/src/test/java/com/tradingsystem/order/config/JpaAuditingTest.java
+++ b/services/order-service/src/test/java/com/tradingsystem/order/config/JpaAuditingTest.java
@@ -1,0 +1,86 @@
+package com.tradingsystem.order.config;
+
+import com.tradingsystem.order.domain.Order;
+import com.tradingsystem.order.domain.OrderSide;
+import com.tradingsystem.order.domain.OrderStatus;
+import com.tradingsystem.order.domain.OrderType;
+import com.tradingsystem.order.repository.OrderRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class JpaAuditingTest {
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Test
+    @DisplayName("JPA Auditing - createdAt 자동 설정")
+    void testCreatedAtAutoPopulated() throws InterruptedException {
+        // given
+        Order order = Order.builder()
+                .userId(1L)
+                .symbol("005930")
+                .side(OrderSide.BUY)
+                .type(OrderType.LIMIT)
+                .price(new BigDecimal(90000))
+                .quantity(10)
+                .filledQuantity(0)
+                .status(OrderStatus.PENDING)
+                .clientOrderId("CLIENT_ORDER_AUDIT")
+                .build();
+
+        LocalDateTime beforeSave = LocalDateTime.now();
+        Thread.sleep(100); // 시간 차이 확보
+
+        // when
+        Order saved = orderRepository.save(order);
+
+        // then
+        assertThat(saved.getCreatedAt()).isNotNull();
+        assertThat(saved.getCreatedAt()).isAfter(beforeSave);
+        assertThat(saved.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("JPA Auditing - updatedAt 자동 갱신")
+    void testUpdatedAtAutoUpdated() throws InterruptedException {
+        // given
+        Order order = Order.builder()
+                .userId(1L)
+                .symbol("005930")
+                .side(OrderSide.BUY)
+                .type(OrderType.LIMIT)
+                .price(new BigDecimal(90000))
+                .quantity(10)
+                .filledQuantity(0)
+                .status(OrderStatus.PENDING)
+                .clientOrderId("CLIENT_ORDER_UPDATE")
+                .build();
+
+        Order saved = orderRepository.saveAndFlush(order);
+        LocalDateTime initialUpdatedAt = saved.getUpdatedAt();
+        LocalDateTime initialCreatedAt = saved.getCreatedAt();
+
+        Thread.sleep(100); // 시간 차이 확보
+
+        // when
+        saved.updateStatus(OrderStatus.ACCEPTED);
+        Order updated = orderRepository.saveAndFlush(saved);
+
+        // then
+        assertThat(updated.getUpdatedAt()).isNotEqualTo(initialUpdatedAt);
+        assertThat(updated.getCreatedAt()).isEqualTo(initialCreatedAt); // createdAt은 불변
+    }
+}

--- a/services/order-service/src/test/java/com/tradingsystem/order/domain/OrderTest.java
+++ b/services/order-service/src/test/java/com/tradingsystem/order/domain/OrderTest.java
@@ -1,0 +1,170 @@
+// src/test/java/com/tradingsystem/order/domain/OrderTest.java
+package com.tradingsystem.order.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class OrderTest {
+
+    private Order limitBuyOrder;
+    private Order marketSellOrder;
+
+    @BeforeEach
+    void setUp() {
+        // 1. 지정가(LIMIT) 매수 주문 (체결 가능, 만료 시간 있음)
+        limitBuyOrder = Order.builder()
+                .userId(1L)
+                .symbol("005930")
+                .side(OrderSide.BUY)
+                .type(OrderType.LIMIT)
+                .price(new BigDecimal("90000"))
+                .quantity(100)
+                .filledQuantity(0)
+                .status(OrderStatus.PENDING)
+                .clientOrderId("LIMIT_001")
+                .expiresAt(LocalDateTime.now().plusDays(1)) // 하루 뒤 만료
+                .build();
+
+        // 2. 시장가(MARKET) 매도 주문 (항상 체결 가능, 만료 시간 없음)
+        marketSellOrder = Order.builder()
+                .userId(2L)
+                .symbol("000660")
+                .side(OrderSide.SELL)
+                .type(OrderType.MARKET)
+                .quantity(50)
+                .filledQuantity(0)
+                .status(OrderStatus.PENDING)
+                .clientOrderId("MARKET_001")
+                .build();
+    }
+
+    //---------------------------------------------------------
+    // 1. 체결 수량 추가 및 상태 업데이트 로직 검증 (addFilledQuantity)
+    //---------------------------------------------------------
+    @Nested
+    @DisplayName("체결 수량 추가 및 상태 업데이트")
+    class AddFilledQuantityTest {
+
+        @Test
+        @DisplayName("부분 체결 시 상태가 PARTIALLY_FILLED로 변경되어야 한다")
+        void testPartialFill() {
+            // when
+            limitBuyOrder.addFilledQuantity(30);
+
+            // then
+            assertThat(limitBuyOrder.getFilledQuantity()).isEqualTo(30);
+            assertThat(limitBuyOrder.getStatus()).isEqualTo(OrderStatus.PARTIALLY_FILLED);
+            assertThat(limitBuyOrder.getRemainingQuantity()).isEqualTo(70);
+        }
+
+        @Test
+        @DisplayName("전부 체결 시 상태가 FILLED로 변경되어야 한다")
+        void testFullFill() {
+            // given: 70개 부분 체결 상태
+            limitBuyOrder.addFilledQuantity(70);
+            assertThat(limitBuyOrder.getStatus()).isEqualTo(OrderStatus.PARTIALLY_FILLED);
+
+            // when: 남은 30개 전부 체결
+            limitBuyOrder.addFilledQuantity(30);
+
+            // then
+            assertThat(limitBuyOrder.getFilledQuantity()).isEqualTo(100);
+            assertThat(limitBuyOrder.getStatus()).isEqualTo(OrderStatus.FILLED);
+            assertThat(limitBuyOrder.getRemainingQuantity()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("체결 수량이 남은 수량을 초과하면 예외가 발생해야 한다")
+        void testOverFillThrowsException() {
+            // when, then
+            assertThrows(IllegalArgumentException.class, () -> {
+                // 주문 수량(100)을 초과하는 101개를 체결 시도
+                limitBuyOrder.addFilledQuantity(101);
+            }, "체결 수량이 남은 수량을 초과할 때 예외가 발생해야 함");
+        }
+    }
+
+    //---------------------------------------------------------
+    // 2. 만료 여부 및 체결 가능 여부 로직 검증 (isExpired, isTradable)
+    //---------------------------------------------------------
+    @Nested
+    @DisplayName("만료 및 체결 가능 상태 검증")
+    class ExpirationAndTradableTest {
+
+        private final LocalDateTime NOW = LocalDateTime.now();
+
+        @Test
+        @DisplayName("지정가 주문은 만료 시간이 지나면 isExpired가 true를 반환해야 한다")
+        void testLimitOrderIsExpired() {
+            // given: 만료 시간이 현재 시간보다 이전인 주문
+            Order expiredOrder = limitBuyOrder.toBuilder()
+                    .expiresAt(NOW.minusHours(1))
+                    .build();
+
+            // then
+            assertThat(expiredOrder.isExpired(NOW)).isTrue();
+            assertThat(expiredOrder.isTradable(NOW)).isFalse(); // 만료되었으므로 체결 불가능
+        }
+
+        @Test
+        @DisplayName("시장가 주문은 isExpired가 항상 false를 반환해야 한다")
+        void testMarketOrderIsNotExpired() {
+            // then
+            assertThat(marketSellOrder.isExpired(NOW.plusYears(100))).isFalse(); // 한참 뒤에도 만료 아님
+            assertThat(marketSellOrder.isTradable(NOW)).isTrue(); // 체결 가능
+        }
+
+        @Test
+        @DisplayName("부분 체결된 지정가 주문은 만료되지 않았다면 체결 가능해야 한다")
+        void testPartiallyFilledOrderIsTradable() {
+            // given: 부분 체결 상태로 변경
+            limitBuyOrder.addFilledQuantity(10);
+
+            // then
+            // 상태: PARTIALLY_FILLED, 만료되지 않음
+            assertThat(limitBuyOrder.isTradable(NOW)).isTrue();
+        }
+
+        @Test
+        @DisplayName("취소된 주문은 isTradable이 false를 반환해야 한다")
+        void testCanceledOrderIsNotTradable() {
+            // given
+            limitBuyOrder.updateStatus(OrderStatus.CANCELLED);
+
+            // then
+            assertThat(limitBuyOrder.isTradable(NOW)).isFalse();
+        }
+    }
+
+    //---------------------------------------------------------
+    // 3. 주문 타입 및 방향 로직 검증
+    //---------------------------------------------------------
+    @Nested
+    @DisplayName("타입 및 방향 확인 메서드")
+    class TypeAndSideTest {
+
+        @Test
+        @DisplayName("주문 타입 및 방향이 정확해야 한다")
+        void testOrderTypeAndSide() {
+            // limitBuyOrder
+            assertThat(limitBuyOrder.isLimitOrder()).isTrue();
+            assertThat(limitBuyOrder.isMarketOrder()).isFalse();
+            assertThat(limitBuyOrder.isBuyOrder()).isTrue();
+            assertThat(limitBuyOrder.isSellOrder()).isFalse();
+
+            // marketSellOrder
+            assertThat(marketSellOrder.isLimitOrder()).isFalse();
+            assertThat(marketSellOrder.isMarketOrder()).isTrue();
+            assertThat(marketSellOrder.isBuyOrder()).isFalse();
+            assertThat(marketSellOrder.isSellOrder()).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
## What
- JpaConfig에서 @EnableJpaAuditing 활성화
- BaseTimeEntity 추상 클래스 생성
- 모든 엔티티가 BaseTimeEntity 상속하여 타임스탬프 자동 관리

## Why
- 생성/수정 시간을 자동으로 관리하여 코드 중복 제거
- 감사(Audit) 추적 기능 향상
- 일관된 타임스탬프 관리

## How
- @CreatedDate, @LastModifiedDate 어노테이션 활용
- EntityListener로 자동 처리
- 모든 엔티티에 일관되게 적용

## Impact
- Breaking: 없음
- Contract: 없음

## Test
- JpaAuditingTest: 타임스탬프 자동 설정/갱신 검증

## Checklist
- [x] JPA Auditing 설정 완료
- [x] 모든 엔티티 적용 확인
- [x] 테스트 작성 및 통과