### PR TITLE
[order] feat: 주문 생성 DTO 및 분산 추적 ID 검증 구현

### DIFF
--- a/services/order-service/src/main/java/com/tradingsystem/order/domain/OutboxEvent.java
+++ b/services/order-service/src/main/java/com/tradingsystem/order/domain/OutboxEvent.java
@@ -7,6 +7,12 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+/**
+ * Outbox Event 엔티티
+ * - CDC(Change Data Capture) 패턴으로 이벤트 발행
+ * - 트랜잭션 내에서 생성 후 Debezium이 Kafka로 자동 발행
+ * - correlationId 포함하여 분산 추적 지원
+ */
 @Entity
 @Table(name = "outbox_events",
         indexes = {
@@ -25,22 +31,54 @@ public class OutboxEvent extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    /**
+     * 이벤트 고유 ID (UUID - 멱등성 보장)
+     */
     @Column(nullable = false, length = 50)
-    private String eventId; // UUID(멱등성 보장)
+    private String eventId;
 
+    /**
+     * 분산 추적 ID (Correlation ID)
+     * - BFF에서 전달받은 요청 추적 ID
+     * - 전체 플로우를 하나의 ID로 추적
+     * - 로그 집계 및 디버깅에 필수
+     */
+    @Column(nullable = false, length = 100)
+    private String correlationId;
+
+    /**
+     * 이벤트 타입
+     * - OrderPlaced, OrderCancelled, OrderExpired 등
+     */
     @Column(nullable = false, length = 50)
-    private String eventType;  // OrderPlaced, OrderCancelled, OrderExpired
+    private String eventType;
 
+    /**
+     * 집합 루트 ID (Order ID)
+     */
     @Column(nullable = false)
-    private Long aggregateId; // Order ID
+    private Long aggregateId;
 
+    /**
+     * 이벤트 페이로드 (JSON 형태)
+     * - 이벤트 상세 데이터
+     * - Consumer가 파싱하여 사용
+     */
     @Column(nullable = false, columnDefinition = "TEXT")
-    private String payload; // JSON 형태의 이벤트 데이터
+    private String payload;
 
+    /**
+     * 발행 여부
+     * - CDC가 자동으로 발행하므로 실제로는 사용 안 할 수도 있음
+     * - 모니터링/추적 목적으로 유지
+     */
     @Column(nullable = false)
     @Builder.Default
     private boolean published = false;
 
+    /**
+     * 발행 완료 시간
+     */
     private LocalDateTime publishedAt;
 
     // === 비즈니스 메서드 ===

--- a/services/order-service/src/main/java/com/tradingsystem/order/dto/request/CreateOrderRequest.java
+++ b/services/order-service/src/main/java/com/tradingsystem/order/dto/request/CreateOrderRequest.java
@@ -1,0 +1,115 @@
+package com.tradingsystem.order.dto.request;
+
+import com.tradingsystem.order.domain.OrderSide;
+import com.tradingsystem.order.domain.OrderStatus;
+import com.tradingsystem.order.domain.OrderType;
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+/**
+ * 주문 생성 요청 DTO
+ * - 시장가/지정가 매수/매도 주문 생성
+ * - Validation 규칙: 시장가는 price 불필요, 지정가는 price 필수
+ * - 한국 주식 시장 규칙 반영 (종목코드 6자리, 가격 정수)
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@ToString
+public class CreateOrderRequest {
+
+    /**
+     * 분산 추적 ID(Correlation ID)
+     * - BFF에서 HTTP Header로 전달(X-Correlation-Id)
+     * - 형식: PREFIX_UUID_v7 (예: ORD_018e8c7a-9c5e-7000-8000-123456789abc)
+     * - 전체 요청 플로우 추적용
+     * - 로그/이벤트에 포함하여 디버깅 용이
+     */
+    @NotBlank(message = "Correlation ID는 필수입니다.")
+    @Pattern(
+            regexp = "^[A-Z]{3}_[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+            message = "Correlation ID 형식이 올바르지 않습니다. (예: ORD_018e8c7a-9c5e-7000-8000-123456789abc)"
+    )
+    private String correlationId;
+
+    /**
+     * 클라이언트 주문 ID (멱등성 보장용)
+     * - 프론트엔드에서 생성 (숫자, 타임스탬프 등)
+     *      * - 중복 주문 방지 (userId + clientOrderId 조합)
+     *      * - 예: "1234567890", "20250111-001", "order-123"
+     *      */
+    @NotBlank(message = "클라이언트 주문 ID는 필수입니다")
+    @Size(min = 1, max = 50, message = "클라이언트 주문 ID는 1~50자여야 합니다")
+    @Pattern(
+             regexp ="^[a-zA-Z0-9-_]+$",
+            message ="클라이언트 주문 ID는 영문, 숫자, 하이픈(-), 언더스코어(_)만 가능합니다"
+    )
+    private String clientOrderId;
+
+    /**
+     * 종목 코드 (한국 주식 6자리 숫자)
+     * - 예: 005930 (삼성전자), 035720 (카카오)
+     * - 앞자리 0 포함 필수
+     */
+    @NotBlank(message = "종목 코드는 필수입니다")
+    @Pattern(regexp = "^[0-9]{6}$", message = "종목 코드는 6자리 숫자여야 합니다")
+    private String symbol;
+
+    /**
+     * 매수/매도 구분
+     */
+    @NotNull(message = "매수/매도 구분은 필수입니다")
+    private OrderSide side;
+
+    /**
+     * 주문 유형(시장가/지정가)
+     */
+    @NotNull(message = "주문 유형은 필수입니다.")
+    private OrderType type;
+
+    /**
+     * 지정가 (지정가 주문인 경우 필수, 한국 주식은 정수만)
+     * - 시장가 주문 : null
+     * - 지정가 주문 : 양수 정수 필수
+     * - 호가 단위는 별도 검증 필요 (1원, 5원, 10원, 50원, 100원)
+     */
+    @Min(value = 1, message = "가격은 1원 이상이어야 합니다")
+    @Max(value = 10000000, message = "가격은 1,000만원을 초과할 수 없습니다")
+    private Integer price;
+
+    // === 비즈니스 검증 메서드 ===
+
+    /**
+     * 시장가 주문 검증
+     * - 시장가는 price가 null이어야 함
+     */
+    public boolean isValidMarketOrder() {
+        return type == OrderType.MARKET && price == null;
+    }
+
+    /**
+     * 지정가 주문 검증
+     * - 지정가는 price가 필수
+     */
+    public boolean isValidLimitOrder() {
+        return type == OrderType.LIMIT && price != null && price > 0;
+    }
+
+    /**
+     * 전체 검증 (컨트롤러 레벨 추가 검증용)
+     */
+    public void validateOrderTypeAndPrice() {
+        if (type == OrderType.MARKET && price != null) {
+            throw new IllegalArgumentException("시장가 주문은 가격을 지정할 수 없습니다");
+        }
+
+        if (type == OrderType.LIMIT && (price == null || price <= 0)) {
+            throw new IllegalArgumentException("지정가 주문은 양수 가격이 필수입니다");
+        }
+    }
+
+
+}

--- a/services/order-service/src/main/java/com/tradingsystem/order/dto/response/OrderResponse.java
+++ b/services/order-service/src/main/java/com/tradingsystem/order/dto/response/OrderResponse.java
@@ -1,0 +1,169 @@
+package com.tradingsystem.order.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.tradingsystem.order.domain.Order;
+import com.tradingsystem.order.domain.OrderSide;
+import com.tradingsystem.order.domain.OrderStatus;
+import com.tradingsystem.order.domain.OrderType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+/**
+ * 주문 응답 DTO
+ * - Entity를 프론트엔드 친화적 형태로 변환
+ * - 필요한 정보만 노출
+ * - 민감 정보 제외
+ * - 한국 주식 : 가격을 Integer로 반환
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@ToString
+public class OrderResponse {
+
+    /**
+     * 주문 ID
+     */
+    private Long orderId;
+
+    /**
+     * 분산 추적 ID (Correlation ID)
+     * - 요청 추적용 (디버깅/모니터링)
+     */
+    private String correlationId;
+
+    /**
+     * 클라이언트 주문 ID (멱등성 확인용)
+     */
+    private String clientOrderId;
+
+    /**
+     * 종목 코드
+     */
+    private String symbol;
+
+    /**
+     * 매수/매도 구분
+     */
+    private OrderSide side;
+
+    /**
+     * 주문 유형 (시장가/지정가)
+     */
+    private OrderType type;
+
+    /**
+     * 지정가 (지정가 주문만 존재, 한국 주식은 정수)
+     */
+    private Integer price;
+
+    /**
+     * 주문 수량
+     */
+    private Integer quantity;
+
+    /**
+     * 체결 수량 (누적)
+     */
+    private Integer filledQuantity;
+
+    /**
+     * 남은 수량
+     */
+    private Integer remainingQuantity;
+
+    /**
+     * 주문 상태
+     */
+    private OrderStatus status;
+
+    /**
+     * 주문 상태 표시명 (프론트엔드용)
+     */
+    private String statusDisplayName;
+
+    /**
+     * 만료 시간(지정가 주문만 존재)
+     */
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime expiresAt;
+
+    /**
+     * 주문 생성 시간
+     */
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime createdAt;
+
+    /**
+     * 주문 수정 시간
+     */
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime updatedAt;
+
+    // === 정적 팩토리 메서드 ===
+
+    /**
+     * Entity → DTO 변환
+     * - BigDecimal → Integer 변환 (한국 주식 정수 가격)
+     *
+     * @param order 주문 엔티티
+     * @param correlationId 분산 추적 ID (서비스 레이어에서 주입)
+     * @return 주문 응답 DTO
+     */
+    public static OrderResponse from(Order order, String correlationId) {
+        return OrderResponse.builder()
+                .orderId(order.getId())
+                .correlationId(correlationId)
+                .clientOrderId(order.getClientOrderId())
+                .symbol(order.getSymbol())
+                .side(order.getSide())
+                .type(order.getType())
+                .price(order.getPrice() != null ? order.getPrice().intValue() : null)
+                .quantity(order.getQuantity())
+                .filledQuantity(order.getFilledQuantity())
+                .remainingQuantity(order.getRemainingQuantity())
+                .status(order.getStatus())
+                .statusDisplayName(order.getStatus().getDisplayName())
+                .expiresAt(order.getExpiresAt())
+                .createdAt(order.getCreatedAt())
+                .updatedAt(order.getUpdatedAt())
+                .build();
+    }
+
+    // === 편의 메서드 ===
+
+    /**
+     * 체결률 계산 (백분율)
+     */
+    public double getFilledPercentage() {
+        if (quantity == 0) {
+            return 0.0;
+        }
+        return (filledQuantity * 100.0) / quantity;
+    }
+
+    /**
+     * 완전 체결 여부
+     */
+    public boolean isFullyFilled() {
+        return status == OrderStatus.FILLED;
+    }
+
+    /**
+     * 부분 체결 여부
+     */
+    public boolean isPartiallyFilled() {
+        return status == OrderStatus.PARTIALLY_FILLED;
+    }
+
+    /**
+     * 활성 상태 여부 (체결 가능 상태)
+     */
+    public boolean isActive() {
+        return status == OrderStatus.PENDING
+                || status == OrderStatus.ACCEPTED
+                || status == OrderStatus.PARTIALLY_FILLED;
+    }
+}

--- a/services/order-service/src/main/java/com/tradingsystem/order/dto/response/PageResponse.java
+++ b/services/order-service/src/main/java/com/tradingsystem/order/dto/response/PageResponse.java
@@ -1,0 +1,130 @@
+package com.tradingsystem.order.dto.response;
+
+import lombok.*;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+/**
+ * 페이징 응답 공통 래퍼
+ *  * - Spring Page<T>를 프론트엔드 친화적으로 변환
+ *  * - 불필요한 필드 제거
+ *  * - 제네릭으로 재사용 가능
+ *  *
+ *  * @param <T> 응답 데이터 타입 (예: OrderResponse)
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@ToString
+public class PageResponse<T> {
+
+    /**
+     * 실제 데이터 목록
+     */
+    private List<T> content;
+
+    /**
+     * 현재 페이지 번호 (0부터 시작)
+     */
+    private int page;
+
+    /**
+     * 페이지당 데이터 개수
+     */
+    private int size;
+
+    /**
+     * 전체 데이터 개수
+     */
+    private long totalElements;
+
+    /**
+     * 전체 페이지 수
+     */
+    private int totalPages;
+
+    /**
+     * 첫 페이지 여부
+     */
+    private boolean isFirst;
+
+    /**
+     * 마지막 페이지 여부
+     */
+    private boolean isLast;
+
+    /**
+     * 다음 페이지 존재 여부
+     */
+    private boolean hasNext;
+
+    /**
+     * 이전 페이지 존재 여부
+     */
+    private boolean hasPrevious;
+
+    // === 정적 팩토리 메서드 ===
+
+    /**
+     * Spring Page<T> → PageResponse<T> 변환
+     * - Java 8 스타일 (정적 팩토리 메서드)
+     *
+     * @param page Spring Data JPA Page 객체
+     * @param <T> 데이터 타입
+     * @return PageResponse 래퍼
+     */
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return PageResponse.<T>builder()
+                .content(page.getContent())
+                .page(page.getNumber())
+                .size(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .isFirst(page.isFirst())
+                .isLast(page.isLast())
+                .hasNext(page.hasNext())
+                .hasPrevious(page.hasPrevious())
+                .build();
+    }
+
+    /**
+     * 빈 페이지 응답 생성
+     *
+     * @param page 페이지 번호
+     * @param size 페이지 크기
+     * @param <T> 데이터 타입
+     * @return 빈 PageResponse
+     */
+    public static <T> PageResponse<T> empty(int page, int size) {
+        return PageResponse.<T>builder()
+                .content(List.of())
+                .page(page)
+                .size(size)
+                .totalElements(0L)
+                .totalPages(0)
+                .isFirst(true)
+                .isLast(true)
+                .hasNext(false)
+                .hasPrevious(false)
+                .build();
+    }
+
+    // === 편의 메서드 ===
+
+    /**
+     * 데이터 존재 여부
+     */
+    public boolean hasContent() {
+        return content != null && !content.isEmpty();
+    }
+
+    /**
+     * 실제 반환된 데이터 개수
+     */
+    public int numberOfElements() {
+        return content != null ? content.size() : 0;
+    }
+
+}

--- a/services/order-service/src/main/java/com/tradingsystem/order/util/CorrelationIdValidator.java
+++ b/services/order-service/src/main/java/com/tradingsystem/order/util/CorrelationIdValidator.java
@@ -1,0 +1,111 @@
+package com.tradingsystem.order.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.regex.Pattern;
+
+/**
+ * Correlation ID 검증 및 추출 유틸리티
+ * - BFF에서 생성한 UUID v7 기반 Correlation ID 검증
+ * - 형식: PREFIX_UUID_v7 (예: ORD_018e8c7a-9c5e-7000-8000-123456789abc)
+ *
+ * 사용처:
+ * 1. Interceptor/Filter - HTTP Header 검증
+ * 2. Kafka Consumer - 이벤트 수신 시 검증
+ * 3. 로깅 MDC - 업무 구분 prefix 추출
+ */
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class CorrelationIdValidator {
+
+    /**
+     * UUID v7 형식 정규식
+     * - 버전: 7 (타임스탬프 포함)
+     * - Variant: RFC 4122 (8, 9, a, b)
+     */
+    private static final Pattern UUID_V7_PATTERN = Pattern.compile(
+            "^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    );
+
+    /**
+     * Correlation ID 전체 형식 정규식
+     * - PREFIX(3자 영문 대문자) + _ + UUID v7
+     */
+    private static final Pattern CORRELATION_ID_PATTERN = Pattern.compile(
+            "^[A-Z]{3}_[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    );
+
+    /**
+     * 주문 플로우 프리픽스
+     */
+    public static final String ORDER_PREFIX = "ORD";
+
+    /**
+     * Correlation ID 형식 검증
+     *
+     * @param correlationId 검증할 Correlation ID
+     * @return 유효한 형식이면 true
+     */
+    public static boolean isValid(String correlationId) {
+        if (correlationId == null || correlationId.isBlank()) {
+            return false;
+        }
+        return CORRELATION_ID_PATTERN.matcher(correlationId).matches();
+    }
+
+    /**
+     * 주문 플로우용 Correlation ID 검증
+     * - ORD_ 프리픽스 확인
+     *
+     * @param correlationId 검증할 Correlation ID
+     * @return ORD 프리픽스이고 유효한 형식이면 true
+     */
+    public static boolean isValidOrderCorrelationId(String correlationId) {
+        return isValid(correlationId) && correlationId.startsWith(ORDER_PREFIX + "_");
+    }
+
+    /**
+     * Correlation ID에서 프리픽스 추출
+     *
+     * @param correlationId Correlation ID
+     * @return 프리픽스 (예: ORD)
+     * @throws IllegalArgumentException 유효하지 않은 형식인 경우
+     */
+    public static String extractPrefix(String correlationId) {
+        if (!isValid(correlationId)) {
+            log.error("Invalid correlationId format: {}", correlationId);
+            throw new IllegalArgumentException("유효하지 않은 Correlation ID 형식입니다: " + correlationId);
+        }
+        return correlationId.substring(0, 3);
+    }
+
+    /**
+     * Correlation ID에서 UUID 부분 추출
+     *
+     * @param correlationId Correlation ID
+     * @return UUID v7 문자열
+     * @throws IllegalArgumentException 유효하지 않은 형식인 경우
+     */
+    public static String extractUuid(String correlationId) {
+        if (!isValid(correlationId)) {
+            log.error("Invalid correlationId format: {}", correlationId);
+            throw new IllegalArgumentException("유효하지 않은 Correlation ID 형식입니다: " + correlationId);
+        }
+        return correlationId.substring(4); // "ORD_" 이후 부분
+    }
+
+    /**
+     * UUID v7 형식 검증
+     *
+     * @param uuid 검증할 UUID 문자열
+     * @return UUID v7 형식이면 true
+     */
+    public static boolean isValidUuidV7(String uuid) {
+        if (uuid == null || uuid.isBlank()) {
+            return false;
+        }
+        return UUID_V7_PATTERN.matcher(uuid).matches();
+    }
+}

--- a/services/order-service/src/test/java/com/tradingsystem/order/util/CorrelationIdValidatorTest.java
+++ b/services/order-service/src/test/java/com/tradingsystem/order/util/CorrelationIdValidatorTest.java
@@ -1,0 +1,118 @@
+package com.tradingsystem.order.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * CorrelationIdValidator 테스트
+ */
+@DisplayName("Correlation ID 검증 유틸리티 테스트")
+class CorrelationIdValidatorTest {
+
+    @Test
+    @DisplayName("유효한 주문 Correlation ID - 성공")
+    void validOrderCorrelationId() {
+        // given
+        String correlationId = "ORD_018e8c7a-9c5e-7000-8000-123456789abc";
+
+        // when & then
+        assertThat(CorrelationIdValidator.isValid(correlationId)).isTrue();
+        assertThat(CorrelationIdValidator.isValidOrderCorrelationId(correlationId)).isTrue();
+    }
+
+    @Test
+    @DisplayName("잘못된 프리픽스 - 실패")
+    void invalidPrefix() {
+        // given
+        String correlationId = "PAY_018e8c7a-9c5e-7000-8000-123456789abc";
+
+        // when & then
+        assertThat(CorrelationIdValidator.isValid(correlationId)).isTrue(); // 형식은 맞음
+        assertThat(CorrelationIdValidator.isValidOrderCorrelationId(correlationId)).isFalse(); // ORD 아님
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "ORD_018e8c7a-9c5e-6000-8000-123456789abc",  // UUID v6 (버전 7 아님)
+            "ORD_018e8c7a-9c5e-4000-8000-123456789abc",  // UUID v4
+            "ORD_018e8c7a-9c5e-7000-c000-123456789abc",  // Variant 오류 (c는 불가)
+            "ord_018e8c7a-9c5e-7000-8000-123456789abc",  // 소문자 프리픽스
+            "ORDR_018e8c7a-9c5e-7000-8000-123456789abc", // 4자 프리픽스
+            "OR_018e8c7a-9c5e-7000-8000-123456789abc",   // 2자 프리픽스
+            "018e8c7a-9c5e-7000-8000-123456789abc",      // 프리픽스 없음
+            "ORD-018e8c7a-9c5e-7000-8000-123456789abc",  // - 구분자
+            ""                                           // 빈 문자열
+    })
+    @DisplayName("잘못된 Correlation ID 형식 - 실패")
+    void invalidCorrelationId(String correlationId) {
+        // when & then
+        assertThat(CorrelationIdValidator.isValid(correlationId)).isFalse();
+    }
+
+    @Test
+    @DisplayName("null Correlation ID - 실패")
+    void nullCorrelationId() {
+        // when & then
+        assertThat(CorrelationIdValidator.isValid(null)).isFalse();
+        assertThat(CorrelationIdValidator.isValidOrderCorrelationId(null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("프리픽스 추출 - 성공")
+    void extractPrefix() {
+        // given
+        String correlationId = "ORD_018e8c7a-9c5e-7000-8000-123456789abc";
+
+        // when
+        String prefix = CorrelationIdValidator.extractPrefix(correlationId);
+
+        // then
+        assertThat(prefix).isEqualTo("ORD");
+    }
+
+    @Test
+    @DisplayName("UUID 추출 - 성공")
+    void extractUuid() {
+        // given
+        String correlationId = "ORD_018e8c7a-9c5e-7000-8000-123456789abc";
+
+        // when
+        String uuid = CorrelationIdValidator.extractUuid(correlationId);
+
+        // then
+        assertThat(uuid).isEqualTo("018e8c7a-9c5e-7000-8000-123456789abc");
+        assertThat(CorrelationIdValidator.isValidUuidV7(uuid)).isTrue();
+    }
+
+    @Test
+    @DisplayName("잘못된 형식에서 추출 시도 - 예외 발생")
+    void extractFromInvalidFormat() {
+        // given
+        String invalidCorrelationId = "INVALID_ID";
+
+        // when & then
+        assertThatThrownBy(() -> CorrelationIdValidator.extractPrefix(invalidCorrelationId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("유효하지 않은 Correlation ID 형식");
+
+        assertThatThrownBy(() -> CorrelationIdValidator.extractUuid(invalidCorrelationId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("유효하지 않은 Correlation ID 형식");
+    }
+
+    @Test
+    @DisplayName("UUID v7 형식 검증")
+    void validateUuidV7() {
+        // given
+        String validUuidV7 = "018e8c7a-9c5e-7000-8000-123456789abc";
+        String invalidUuidV4 = "123e4567-e89b-42d3-a456-426614174000"; // v4
+
+        // when & then
+        assertThat(CorrelationIdValidator.isValidUuidV7(validUuidV7)).isTrue();
+        assertThat(CorrelationIdValidator.isValidUuidV7(invalidUuidV4)).isFalse();
+    }
+}


### PR DESCRIPTION
### What
- CreateOrderRequest: 주문 생성 요청 DTO (Validation 포함)
- OrderResponse: 주문 응답 DTO (Entity → DTO 변환)
- PageResponse<T>: 페이징 공통 래퍼
- CorrelationIdValidator: UUID v7 기반 분산 추적 ID 검증
- OutboxEvent: correlationId 필드 추가

### Why
- DTO 클래스 작성
- 한국 주식 시장 규칙 반영 (종목코드 6자리, 가격 정수)
- 전체 플로우 추적을 위한 correlationId 지원

### How
- DTO는 Integer, Entity는 BigDecimal 유지 (확장성)
- Validation으로 입력 검증
- 정적 팩토리 메서드로 변환 처리

### Impact
- Breaking: 없음
- 신규 DTO 3개 추가

### Test
- CorrelationIdValidator 단위 테스트 11개 통과
- DTO 직렬화 테스트는 Postman으로 수동 확인 예정

Close #22 